### PR TITLE
routes are protected via the Auth-Guard and the jwt is stored in loca…

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,7 @@
 import { Component } from '@angular/core';
+import { jwtDecode } from 'jwt-decode';
+import { authActions } from './store/auth-feature/auth.actions';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'app-root',
@@ -7,5 +10,23 @@ import { Component } from '@angular/core';
   styleUrl: './app.component.css'
 })
 export class AppComponent {
-  
-}
+  // when the user first authenticated and dispatched an authentication action, and got the token from the backend
+  // we stored the token in local storage
+  // so that when we reload the page (the state empties)
+  // we will use that stored token, by decoding it and extracting claims then dispatching an action that will refresh the state to have the claims, and the routingn will take place to dashboard
+  constructor(private store: Store){}
+  ngOnInit(): void {
+    const token = localStorage.getItem('jwt-token');
+    if (token) {
+      const decodedToken = jwtDecode(token);
+      this.store.dispatch(authActions.authenticateSuccessWithClaims({
+        payload: {
+          jwt: token,
+          userClaims: {
+            username: decodedToken.sub,
+            roles: (decodedToken as any).scope,
+          },
+        },
+      }));
+    }
+  }}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,7 @@ import { DemandesComponent } from './components/admin/demandes/demandes.componen
 import { DashboardComponent } from './components/admin/dashboard/dashboard.component';
 import { HistoriqueComponent } from './components/admin/historique/historique.component';
 import { ReclamationsComponent } from './components/admin/reclamations/reclamations.component';
+import { AuthGuard } from './guards/auth.guard';
 
 // the paths we have
 //---------level 1
@@ -46,11 +47,14 @@ export const routes: Routes = [
   {
     path: 'admin',
     component: AdminComponent,
+    canActivate: [AuthGuard],
     children: [
-      { path: 'demandes', component: DemandesComponent },
-      { path: 'dashboard', component: DashboardComponent },
-      { path: 'reclamations', component: ReclamationsComponent },
-      { path: 'historique', component: HistoriqueComponent },
+      { path: 'demandes', component: DemandesComponent ,canActivate: [AuthGuard],},
+      { path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard], },
+      { path: 'reclamations', component: ReclamationsComponent , canActivate: [AuthGuard],},
+      { path: 'historique', component: HistoriqueComponent, canActivate: [AuthGuard], },
     ],
   },
+  
+  { path: '**', redirectTo: '/home' },
 ];

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { selectUserClaims } from '../store/auth-feature/auth.selectors';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthGuard implements CanActivate {
+  constructor(private store: Store, private router: Router) {}
+
+  canActivate(): Observable<boolean> {
+    return this.store.select(selectUserClaims).pipe(
+      map((claims) => {
+        if (claims.roles.includes('ADMIN')) {
+          return true; // User is an admin
+        } else {
+          this.router.navigate(['/']); // Redirect if not an admin
+          return false; // Access denied
+        }
+      })
+    );
+  }
+  
+}
+
+
+
+/*
+
+Prevents Unauthorized Access:
+Before navigating to a route, CanActivate runs logic to decide if the user can proceed to that route.
+
+Runs Before Route Activation:
+It intercepts the navigation process and either:
+
+Allows navigation (returns true).
+Prevents navigation (returns false) and optionally redirects the user to another route (e.g., a login page).
+
+*/

--- a/src/app/store/auth-feature/auth.effects.ts
+++ b/src/app/store/auth-feature/auth.effects.ts
@@ -29,7 +29,7 @@ export class AuthEffects {
                 (token) => { // this variable has the coded jwt, we need to decode it and extract the claims , here its in this form : {'access-token':'token'} ;
                     const access_token = token['access-token'];
                     const decodedToken = jwtDecode(access_token);
-                    window.localStorage.setItem('jwt-token', access_token); // here we put the token in our local storage
+                    localStorage.setItem('jwt-token', access_token); // here we put the token in our local storage
                   return authActions.authenticateSuccessWithClaims({ // when the authenticateSuccess action is dispatched we will pass a decoded token to it
                     payload: {
                         userClaims : {


### PR DESCRIPTION
…l storage and used when we reload the page so that we dont get redirected to /home

The main idea is that when a user authenticates, we receive a JWT token from the backend. This token is decoded to extract user claims (like roles and username), and an action is dispatched to update the state with these claims. The updated state is then used by various parts of the application, including guards, to determine access to specific routes. However, if the page is reloaded, the state resets to its initial state, meaning the claims and authentication information are lost. In this case, guards would redirect the user (e.g., an admin) back to the login page because there’s no indication that the user is authenticated. To address this, we store the JWT token in local storage upon authentication. When the app initializes (e.g., after a reload), the token is retrieved from local storage, decoded, and the same action used during login is dispatched again to restore the state, ensuring a seamless user experience without forcing reauthentication.